### PR TITLE
Added default GitHub branch detection

### DIFF
--- a/mister_updater.sh
+++ b/mister_updater.sh
@@ -523,15 +523,13 @@ function checkCoreURL {
 	# else
 	# 	RELEASES_URL=https://github.com$(curl $CURL_RETRY $SSL_SECURITY_OPTION -sSLf "$CORE_URL" | grep -oi '/MiSTer-devel/[a-zA-Z0-9./_-]*/tree/[a-zA-Z0-9./_-]*/releases' | head -n1)
 	# fi
+	BRANCH_NAME=$(curl $CURL_RETRY $SSL_SECURITY_OPTION -sSLf "${CORE_URL}/branches" | grep "branch-name" | head -n1 | sed 's/.*>\(.*\)<.*/\1/')
 	case "$CORE_URL" in
 		*SD-Installer*)
 			RELEASES_URL="$CORE_URL"
 			;;
-		*Minimig*)
-			RELEASES_URL="${CORE_URL}/file-list/MiSTer/releases"
-			;;
 		*)
-			RELEASES_URL="${CORE_URL}/file-list/master/releases"
+			RELEASES_URL="${CORE_URL}/file-list/${BRANCH_NAME}/releases"
 			;;
 	esac
 	RELEASES_HTML=""


### PR DESCRIPTION
This is to address https://github.com/MiSTer-devel/Updater_script_MiSTer/issues/51 by detecting the repository's default branch, per Sorgelig's suggestion.